### PR TITLE
add Safari 6.1/7.0 support

### DIFF
--- a/book.js
+++ b/book.js
@@ -1241,11 +1241,13 @@
                 setTimeout(redoToc, 0);
                 
             });
-            document.fontloader.addEventListener('loadingdone', function() {
-                // When fonts have been loaded, update the body layout.
-                // TODO: This does not seem to work at all times. 
-                document.body.dispatchEvent(pagination.events.bodyLayoutUpdated);
-            });
+            if (document.hasOwnProperty('fontloader')) {
+            	document.fontloader.addEventListener('loadingdone', function() {
+                	// When fonts have been loaded, update the body layout.
+                	// TODO: This does not seem to work at all times. 
+                	document.body.dispatchEvent(pagination.events.bodyLayoutUpdated);
+            	});
+            }
         }
         if (pagination.config('enableCrossReferences')) {
             pagination.findAllCrossReferences();
@@ -2144,6 +2146,14 @@
         
         
         flowObject.namedFlow.addEventListener("webkitregionoversetchange", checkOverset);
+
+        if (navigator.userAgent.indexOf('6.1 Safari/') > -1 
+        || navigator.userAgent.indexOf('7.0 Safari/') > -1) {
+            /* Safari 6.1/7 does not include the regionoversetchange event. 
+             * Newer versions should drop the regionlayoutupdate event.
+         	 */
+        	flowObject.namedFlow.addEventListener("webkitregionlayoutupdate", checkOverset);
+        }
 
         flowObject.currentlyChecking = false;
         

--- a/index.html
+++ b/index.html
@@ -6,10 +6,14 @@
 
 <h2>Steps:</h2>
 <ol>
-  <li>Download a recent version of Chromium/Chrome (29+)</li>
-  <li>In Chrome/Chromium open a new tab and go to "<code>chrome://flags/</code>"</li>
-  <li>Search for "Webkit Experimental Features" and enable them</li>
-  <li>Restart your browser</li>
+  <li>Download a recent version of Chromium/Chrome (29+) or Safari 6.1/7.0</li>
+  <li>If you use Chrome/Chromium:
+  <ul>
+  	<li>Open a new tab and go to "<code>chrome://flags/</code>"</li>
+  	<li>Search for "Webkit Experimental Features" and enable them</li>
+  	<li>Restart your browser</li>
+  </ul>
+  </li>
   <li>Read the "Notice" below so you know what to look for and then</li>
   <li>Check out the <a href="test.html">simple test book</a>, a book with <a href="test2.html">many chapters</a>, or a book with a <a href="test3.html">very long chapter</a>, <a href="test4.html">top floats</a>.</li>
 </ol>
@@ -30,7 +34,7 @@
 <p>In order to insert a footnote into the source text, simply insert it as a span with a class 'pagination-footnote', such as <i>&lt;span class='pagination-footnote'&gt;&lt;span&gt;&lt;span&gt;This a footnote&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</i>. See also the source code of the <a href="test.html">Test Page</a>.</p>
 
 <h2>License:</h2>
-BookJS is licensed under the APL license. For further information, check <a href="LICENSE.txt">LICENSE.txt</a>.
+BookJS is licensed under the AGPL license. For further information, check <a href="LICENSE.txt">LICENSE.txt</a>.
 
 
 </body>


### PR DESCRIPTION
Hey,
Safari 6.1/7.0 come with CSS Region support as default. I have had access to a machine with Safari 6.1 seed 8 and made BookJS run on it. This should also work in Safari 7.0, even though I haven't been able to check that.
